### PR TITLE
minimal WIN32 support added

### DIFF
--- a/common.h
+++ b/common.h
@@ -3,7 +3,14 @@
 
 
 #include <sys/stat.h>
+#if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__)
 #include <alloca.h>
+#elif defined(_WIN32)
+#include <malloc.h>
+#if !defined(alloca)
+#define alloca _alloca  // for clang with MS Codegen
+#endif
+#endif
 #include <errno.h>
 #include <unistd.h>
 

--- a/libkeccak_generalised_sum_fd.c
+++ b/libkeccak_generalised_sum_fd.c
@@ -19,16 +19,20 @@ libkeccak_generalised_sum_fd(int fd, struct libkeccak_state *restrict state, con
                              const char *restrict suffix, void *restrict hashsum)
 {
 	ssize_t got;
+#ifndef _WIN32
 	struct stat attr;
+#endif
 	size_t blksize = 4096;
 	void *restrict chunk;
 
 	if (libkeccak_state_initialise(state, spec) < 0)
 		return -1;
 
+#ifndef _WIN32
 	if (fstat(fd, &attr) == 0)
 		if (attr.st_blksize > 0)
 			blksize = (size_t)attr.st_blksize;
+#endif
   
 	chunk = alloca(blksize);
 


### PR DESCRIPTION
this PR fixes the `alloca.h` issue under WIN32 env.

```
$ CC=x86_64-w64-mingw32-gcc make CFLAGS="-D_WIN32"
...
```

reference https://github.com/ocornut/imgui/issues/1917