### PR TITLE
Include alloca.h on macOS

### DIFF
--- a/common.h
+++ b/common.h
@@ -9,7 +9,7 @@
 
 #include <sys/stat.h>
 #if ALLOCA_LIMIT > 0
-# if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__)
+# if defined(__GLIBC__) || defined(__sun) || defined(__CYGWIN__) || defined(__APPLE__)
 #  include <alloca.h>
 # elif defined(_WIN32)
 #  include <malloc.h>


### PR DESCRIPTION
While packaging `libkeccak` 1.2.1 on Homebrew package manager, we encountered this error:

```
ar -s libkeccak.a
Undefined symbols for architecture x86_64:
  "_alloca", referenced from:
      _libkeccak_generalised_sum_fd in libkeccak_generalised_sum_fd.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [libkeccak.dylib] Error 1
```

Adding the `alloca.h` header allows for successful install.

Downstream issue: https://github.com/Homebrew/homebrew-core/pull/82162

Thanks!