### PR TITLE
Fix library install name in `install` target on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,9 @@ run-benchmark: benchmark benchfile
 	for i in $$(seq 7) ; do ./benchmark ; done | median
 
 install: libkeccak.$(LIBEXT) libkeccak.a
+ifeq ($(shell uname),Darwin)
+	install_name_tool -id "$(PREFIX)/lib/libkeccak.$(LIBMAJOREXT)" libkeccak.$(LIBEXT)
+endif
 	mkdir -p -- "$(DESTDIR)$(PREFIX)/lib"
 	cp -- libkeccak.$(LIBEXT) "$(DESTDIR)$(PREFIX)/lib/libkeccak.$(LIBMINOREXT)"
 	ln -sf -- libkeccak.$(LIBMINOREXT) "$(DESTDIR)$(PREFIX)/lib/libkeccak.$(LIBMAJOREXT)"


### PR DESCRIPTION
On macOS, libraries have "install names" which the linker records in a
binary that links against the library. At runtime, the dynamic loader
uses this install name to work out where to find the linked library.

Currently, the Makefile passes no information about the install name to
the linker, and so the DSO has an install name of `libkeccak.dylib`.
This is a problem when you link something against `libkeccak` but
install it outside the default linker search path, because the dynamic
loader won't be able to find it.

This change fixes that by making sure the dynamic loader will always be
able to find `libkeccak.dylib` regardless of where it's been installed.

We use `LIBMAJOREXT` since this is the typical convention for library
install names. For example, the system libc++ has an install name of
`libc++.1.dylib`, in the same way that `SONAME` also typically includes
the library major version on Linux.
